### PR TITLE
fix: use SemanticReleaseError to support fail lifecycle method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import SemanticReleaseError from "@semantic-release/error";
 import fs from "node:fs/promises";
 import path from "node:path";
 import c from "picocolors";
@@ -118,7 +119,7 @@ export async function verifyConditions(
 			if (DEBUG) {
 				logger.log(message + ", throwing");
 			}
-			throw new Error(message);
+			throw new SemanticReleaseError(message, "EPUBLINT");
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"@semantic-release/error": "^4.0.0",
 				"picocolors": "^1.0.1",
 				"publint": "^0.2.9"
 			},
@@ -417,7 +418,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
 			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	"license": "MIT",
 	"description": "Run publint as part of the verify step in semantic-release.",
 	"dependencies": {
+		"@semantic-release/error": "^4.0.0",
 		"picocolors": "^1.0.1",
 		"publint": "^0.2.9"
 	},


### PR DESCRIPTION
Should let for instance `@semantic-release/github` open an issue should validation fail